### PR TITLE
Tweaked "Enable Blueprint scaling" config line appearance

### DIFF
--- a/TransformAnarchy/TA.cs
+++ b/TransformAnarchy/TA.cs
@@ -9,7 +9,7 @@ namespace TransformAnarchy
 {
     public class TA : AbstractMod, IModSettings
     {
-        public const string VERSION_NUMBER = "1.4";
+        public const string VERSION_NUMBER = "1.4.1";
         public override string getIdentifier() => "com.parkitectCommunity.TA";
         public override string getName() => "Transform Anarchy";
         public override string getDescription() => @"Adds an advanced building gizmo for select building types.";

--- a/TransformAnarchy/TA.cs
+++ b/TransformAnarchy/TA.cs
@@ -144,6 +144,11 @@ namespace TransformAnarchy
             guistyleTextMiddle.margin = new RectOffset(0, 10, 10, 0);
             guistyleTextMiddle.alignment = TextAnchor.MiddleCenter;
 
+            GUIStyle guistyleTextSmall = new GUIStyle(GUI.skin.label);
+            guistyleTextSmall.margin = new RectOffset(0, 0, 16, 0);
+            guistyleTextSmall.alignment = TextAnchor.MiddleLeft;
+            guistyleTextSmall.fontSize = Mathf.RoundToInt(guistyleTextSmall.fontSize * 0.65f);
+
             GUIStyle guistyleField = new GUIStyle(GUI.skin.textField);
             guistyleField.margin = new RectOffset(0, 10, 10, 0);
             guistyleField.alignment = TextAnchor.MiddleCenter;
@@ -169,10 +174,16 @@ namespace TransformAnarchy
 
             GUILayout.Space(10);
 
-            TASettings.enableBlueprintScaling = GUILayout.Toggle(TASettings.enableBlueprintScaling, " Enable Blueprint scaling");
-            GUILayout.Label("Blueprint scaling is not supported in Multiplayer.", guistyleTextMiddle);
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Enable Blueprint scaling", guistyleTextLeft, GUILayout.Width(175));
+            GUILayout.BeginVertical();
+            GUILayout.Space(12);
+            TASettings.enableBlueprintScaling = GUILayout.Toggle(TASettings.enableBlueprintScaling, " ");
+            GUILayout.EndVertical();
+            GUILayout.Label("Blueprint scaling is not supported in Multiplayer.", guistyleTextSmall);
+            GUILayout.EndHorizontal();
 
-            GUILayout.Space(10);
+            GUILayout.Space(40);
             GUILayout.BeginHorizontal();
             if (GUILayout.Button("Advanced settings", guistyleButton, GUILayout.Width(125))) {
                 TASettings.showAdvancedSettings = !TASettings.showAdvancedSettings;


### PR DESCRIPTION
Minor tweak to appearance of "Enable Blueprint scaling" toggle line in config menu.

Old layout:
<img width="964" height="292" alt="image" src="https://github.com/user-attachments/assets/afe6dbb6-f816-4b01-98f8-f6826cf061bb" />

New layout:
<img width="964" height="296" alt="image" src="https://github.com/user-attachments/assets/3b624bb5-31a7-42f1-bf92-b54ead2b65c8" />